### PR TITLE
Build and deploy CI containers

### DIFF
--- a/.github/docker/build.Dockerfile
+++ b/.github/docker/build.Dockerfile
@@ -1,0 +1,16 @@
+# This image shall be used for building Triton packages in CI environment
+# Workflow expression: ghcr.io/${{ github.repository }}/build:latest
+
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+RUN dnf update \
+    && dnf install -y clang lld \
+    && dnf clean all
+
+RUN mkdir /root/ccache \
+    && cd /root/ccache \
+    && curl -Lo cc.tar.xz https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz \
+    && tar xf cc.tar.xz \
+    && cd ccache* \
+    && make install \
+    && rm -r /root/ccache

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: '.github/docker'
-          submodules: false
       - name: Define variables
         id: vars
         run: |

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,44 @@
+name: Containers
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy-build-image:
+        description: Deploy triton_acc/build:latest
+        type: boolean
+        required: true
+        default: false
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/docker/**'
+      - '.github/workflows/containers.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy-build-image:
+    name: Deploy triton_acc/build:latest
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy-build-image == true }}
+    steps:
+      - name: Initialize a repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github/docker'
+          submodules: false
+      - name: Define variables
+        id: vars
+        run: |
+          image_name="ghcr.io/${{ github.repository }}/build"
+          tag="latest"
+          echo "image-name-tag=$image_name:$tag" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
+      - name: Build an image
+        run: docker build -t ${{ steps.vars.outputs.image-name-tag }} -f .github/docker/build.Dockerfile .
+      - name: Login to the registry
+        run: docker login -u ${{ github.actor }} -p ${{ github.token }} ghcr.io
+      - name: Push an image
+        run: docker push ${{ steps.vars.outputs.image-name-tag }}


### PR DESCRIPTION
GitHub will update images on ghcr.io automatically when changes in related files (Dockerfile and containers.yml) are pushed to main branch. Also Containers workflow can be triggered manually with selected images to build.